### PR TITLE
Update glfw to 3.4

### DIFF
--- a/com.pokemmo.PokeMMO.yaml
+++ b/com.pokemmo.PokeMMO.yaml
@@ -22,11 +22,12 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - -DBUILD_SHARED_LIBS:BOOL=ON
-      - -DGLFW_USE_WAYLAND=ON
+      - -DGLFW_BUILD_WAYLAND=ON
+      - -DGLFW_BUILD_X11=ON
     sources:
       - type: git
         url: https://github.com/glfw/glfw.git
-        commit: 3eaf1255b29fdf5c2895856c7be7d7185ef2b241
+        commit: 7b6aead9fb88b3623e3b3725ebb42670cbe4c579
     cleanup:
       - /include
       - /lib/cmake


### PR DESCRIPTION
Building from master fails with:

```
/usr/include/c++/13.2.0/string_view:258: constexpr const std::basic_string_view<_CharT, _Traits>::value_type& std::basic_string_view<_CharT, _Traits>::operator[](size_type) const [with _CharT = char; _Traits = std::char_traits<char>; const_reference = const char&; size_type = long unsigned int]: Assertion '__pos < this->_M_len' failed.
[34/116] Building C object src/CMakeFiles/glfw.dir/x11_window.c.o
ninja: build stopped: subcommand failed.
Error: module glfw: Child process exited with code 1
```

Updating to the 3.4 release of glfw builds just fine. See https://github.com/glfw/glfw/releases/tag/3.4